### PR TITLE
Add return type to rememo jsDoc type annotations

### DIFF
--- a/rememo.js
+++ b/rememo.js
@@ -120,6 +120,7 @@ function isShallowEqual(a, b, fromIndex) {
  * @param {S} selector Selector function.
  * @param {GetDependants=} getDependants Dependant getter returning an array of
  * references used in cache bust consideration.
+ * @return {S} Memoized selector.
  */
 export default function (selector, getDependants) {
 	/** @type {WeakMap<*,*>} */


### PR DESCRIPTION
## What problem does this PR solve?

Right now, the `createSelector` function loses the selector type details:

```ts
const iReturnNumbers = createSelector(
	( stringArg: string ) => 123,
	() => []
);
const iShouldBeANumber = iReturnNumbers();
// iShouldBeANumber is of type `any`
```

This is a problem in Gutenberg which depends on this package. For example, see the following PR: https://github.com/WordPress/gutenberg/pull/41235#discussion_r879368708

## How does this PR propose to solve this problem?

Adding the following `@return` type annotation preserves the selector type signature:

```
 * @return {S} Memoized selector.
```

The above snippet now works as expected:

```ts
const iReturnNumbers = createSelector(
	( stringArg: string ) => 123,
	() => []
);
const iShouldBeANumber = iReturnNumbers();
// iShouldBeANumber is of type `number`
```

## Test plan

This changes just the documentation string, there are no runtime changes to test. Eyeballing the changes and confirming the types are now resolved as in the above examples should suffice.

Caveat: this could be considered a breaking change for any projects using `createSelector` in TypeScript. After upgrading rememo to a patched version, the selectors will be of a different type, which could cause type errors. This could be addressed by releasing a new major point release.

cc @aduth @dmsnell