### PR TITLE
Fix selectors with empty args not cached

### DIFF
--- a/rememo.js
+++ b/rememo.js
@@ -271,7 +271,7 @@ export default function (selector, getDependants) {
 		});
 
 		// Avoid including the source object in the cache.
-		args[0] = null;
+		if (args.length > 0) args[0] = null;
 		node.args = args;
 
 		// Don't need to check whether node is already head, since it would

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,23 @@ describe('createSelector', () => {
 		assert.deepEqual(completed, selector(state, true, obj));
 	});
 
+	it('caches return value for empty args', () => {
+		let shouldCache = false;
+		const getValue = sandbox.spy(() => []);
+		const memoedGetValue = createSelector(getValue, () => [shouldCache]);
+
+		const initial = memoedGetValue();
+		sinon.assert.calledOnce(getValue);
+		const cached = memoedGetValue();
+		sinon.assert.calledOnce(getValue);
+		assert.strictEqual(initial, cached);
+
+		shouldCache = true;
+		const notCached = memoedGetValue();
+		sinon.assert.calledTwice(getValue);
+		assert.notStrictEqual(cached, notCached);
+	});
+
 	it('defaults to caching on entire state object', () => {
 		const getTasksByCompletionOnState = createSelector(selector);
 		let state = getState();


### PR DESCRIPTION
I accidentally found out that selectors with empty arguments won't get cached. It's useful for one-off selectors that have heavy computations that don't take any inputs.

```js
import createSelector from 'rememo';

const selector = createSelector(() => {
  console.log('ran');
  someHeavyComputation();
  return {}; // new instance
});

const prev = selector();
const next = selector();
console.log(prev === next);

// 'ran'
// 'ran'
// false
```

I expect the log output to be this instead:

```
'ran'
true
```

I'm not sure if the fix here is optimal but it passes the tests 🎉.